### PR TITLE
[FIX] privacy_consent: Test at install

### DIFF
--- a/privacy_consent/tests/test_consent.py
+++ b/privacy_consent/tests/test_consent.py
@@ -5,11 +5,9 @@
 from contextlib import contextmanager
 
 from odoo.exceptions import ValidationError
-from odoo.tests.common import at_install, post_install, HttpCase
+from odoo.tests.common import HttpCase
 
 
-@at_install(False)
-@post_install(True)
 class ActivityCase(HttpCase):
     def setUp(self):
         super(ActivityCase, self).setUp()


### PR DESCRIPTION
The purpose of this `@post_install` no longer exists, and by removing these decorators, we avoid test failures in case some custom addon customizes the welcome message.

@Tecnativa