### PR TITLE
[8.0][privacy_right_to_be_forgotten ]Recursively erase partner childs datas

### DIFF
--- a/privacy_right_to_be_forgotten/README.rst
+++ b/privacy_right_to_be_forgotten/README.rst
@@ -51,7 +51,8 @@ Images
 Contributors
 ------------
 
-* George Daramouskas <gdaramouskas@therp.nl>  
+* George Daramouskas <gdaramouskas@therp.nl>
+* Florian da Costa <florian.dacosta@akretion.com>
 
 Do not contact contributors directly about help with questions or problems concerning this addon, but use the `community mailing list <mailto:community@mail.odoo.com>`_ or the `appropriate specialized mailinglist <https://odoo-community.org/groups>`_ for help, and the bug tracker linked in `Bug Tracker`_ above for technical issues.
 

--- a/privacy_right_to_be_forgotten/tests/common.py
+++ b/privacy_right_to_be_forgotten/tests/common.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openerp.tests.common import SingleTransactionCase
+from ..wizards.res_partner_gdpr import FIELDS_GDPR
+
+
+class TestPrivacyGdpr(SingleTransactionCase):
+
+    def _create_test_customer(self):
+        vals = {}
+        for field in FIELDS_GDPR:
+            if field == 'name':
+                vals.update({field: 'Name'})
+            else:
+                vals.update({field: False})
+        return self.env['res.partner'].create(vals)
+
+    def _gdpr_cleanup(self, customer):
+        wiz = self.env['res.partner.gdpr'].create({
+            'partner_ids': [(6, False, customer.ids)]})
+        self.assertTrue(wiz.fields, True)
+        wiz.action_gdpr_res_partner_cleanup()

--- a/privacy_right_to_be_forgotten/tests/test_privacy_right_to_be_forgotten.py
+++ b/privacy_right_to_be_forgotten/tests/test_privacy_right_to_be_forgotten.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from openerp.tests.common import SingleTransactionCase
+from .common import TestPrivacyGdpr
 from ..wizards.res_partner_gdpr import FIELDS_GDPR
 
-CLEANUP_STRING = '*** GDPR removed ***'
 
-
-class TestPrivacyGdpr(SingleTransactionCase):
+class TestPrivacyGdprPartner(TestPrivacyGdpr):
 
     at_install = False
     post_install = True
@@ -18,20 +16,14 @@ class TestPrivacyGdpr(SingleTransactionCase):
         self._gdpr_cleanup(customer)
         for field in FIELDS_GDPR:
             attr = getattr(customer, field)
-            if attr:
+            if attr and isinstance(attr, basestring):
                 self.assertTrue(res_partner_gdpr._get_remove_text() in attr)
 
-    def _create_test_customer(self):
-        vals = {}
-        for field in FIELDS_GDPR:
-            if field == 'name':
-                vals.update({field: 'Name'})
-            else:
-                vals.update({field: False})
-        return self.env['res.partner'].create(vals)
-
-    def _gdpr_cleanup(self, customer):
-        wiz = self.env['res.partner.gdpr'].create({
-            'partner_ids': [(6, False, customer.ids)]})
-        self.assertTrue(wiz.fields, True)
-        wiz.action_gdpr_res_partner_cleanup()
+    def test_child_removal(self):
+        res_partner_gdpr = self.env['res.partner.gdpr']
+        customer = self._create_test_customer()
+        child = self.env['res.partner'].create({
+            'parent_id': customer.id,
+            'name': 'Child Partner'})
+        self._gdpr_cleanup(customer)
+        self.assertTrue(res_partner_gdpr._get_remove_text() in child.name)

--- a/privacy_right_to_be_forgotten/wizards/res_partner_gdpr.py
+++ b/privacy_right_to_be_forgotten/wizards/res_partner_gdpr.py
@@ -18,6 +18,7 @@ FIELDS_GDPR = [
     'email',
     'title',
     'child_ids',
+    'comment',
 ]
 
 


### PR DESCRIPTION
Small improvment of the module.
Today, if you erase a partner data, it is still linked to its childs and the childs datas are still there.
I think  we can safely say that if we erase the data of a partner, we want to do the same with the different contacts right?
That is what I implement in this PR.
I also did a small refactore adding a `_do_gdpr_cleanup` method.
The things done here are totally generic and should not be restricted to the partner model only. (the goal is to reuse the same method for other models (crm.lead, sale.order...)

Finally, I also change the special logic for many2many and one2many because putting the value `False` has no effect.
I fixed it for many2many with the right format : `(5, _, _)`
And did nothing for one2many for now, because I think it is not as simple... (You may want to erase data for a one2many, like child_ids, but you also may want to delete it, or simply remove the link...

@daramousk @hbrunn @dreispt 
Let me know what you think,
Thanks