### PR TITLE
[FIX] privacy_consent: Avoid race condition when sending emails

### DIFF
--- a/privacy_consent/models/privacy_activity.py
+++ b/privacy_consent/models/privacy_activity.py
@@ -131,6 +131,9 @@ class PrivacyActivity(models.Model):
                     "accepted": one.default_consent,
                     "activity_id": one.id,
                 })
+        # Avoid race condition where a user could click on accept/reject link
+        # in his email before its consent record is saved to the database
+        consents.env.cr.commit()
         # Send consent request emails for automatic activitys
         consents.action_auto_ask()
         # Redirect user to new consent requests generated


### PR DESCRIPTION
It could happen that, while Odoo is still sending emails, a subject receives it and clicks on accept/reject links.

In such case, he'd get a 404 error because the record wouldn't exist yet in the database. That's because the DB commit was made only after processing all the sent emails.

We need to commit in advance to make sure that doesn't happen.

@Tecnativa