### PR TITLE
[10.0][IMP] privacy_consent: Add full manual + dates

### DIFF
--- a/privacy_consent/models/privacy_activity.py
+++ b/privacy_consent/models/privacy_activity.py
@@ -29,10 +29,16 @@ class PrivacyActivity(models.Model):
         compute="_compute_consent_count",
     )
     consent_required = fields.Selection(
-        [("auto", "Automatically"), ("manual", "Manually")],
+        [("auto", "Automatically"),
+         ("manual", "Manually"),
+         ("full_manual", "Full Manual")],
         "Ask subjects for consent",
         help="Enable if you need to track any kind of consent "
-             "from the affected subjects",
+             "from the affected subjects\n"
+             "[Automatically] Generates consent and send email "
+             "automatically.\n"
+             "[Manually] Generates consent and allow to send email manually\n"
+             "[Full manual] Allow to manage consents steps manually.",
     )
     consent_template_id = fields.Many2one(
         "mail.template",

--- a/privacy_consent/readme/CONTRIBUTORS.rst
+++ b/privacy_consent/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Jairo Llopis
+
+* Denis Roussel <denis.roussel@acsone.eu>

--- a/privacy_consent/readme/USAGE.rst
+++ b/privacy_consent/readme/USAGE.rst
@@ -13,6 +13,9 @@ New options for data processing activities:
    * *Automatic* enables this module's full power: send all consent requests
      to selected partners automatically, every day and under your demand.
 
+   * *Full Manual* tells the activity that you will want to create and send the
+     consent requests manually, and can manage consent states manually.
+
 #. When you do this, all the consent-related options appear. Configure them:
 
    * A smart button tells you how many consents have been generated, and lets you

--- a/privacy_consent/views/privacy_consent.xml
+++ b/privacy_consent/views/privacy_consent.xml
@@ -16,6 +16,28 @@
                         class="oe_highlight"
                         string="Ask for consent"
                     />
+                    <button
+                        type="object"
+                        name="action_set_awaiting"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', ('consent_required', '!=', 'full_manual'), ('state', '!=', 'draft')]}"
+                        string="Set to Awaiting"
+                    />
+                    <button
+                        type="object"
+                        name="action_set_accepted"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', ('consent_required', '!=', 'full_manual'), ('state', 'not in', ('draft', 'sent'))]}"
+                        string="Accepted"
+                    />
+                    <button
+                        type="object"
+                        name="action_set_accepted"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', ('consent_required', '!=', 'full_manual'), ('state', 'not in', ('draft', 'sent'))]}"
+                        string="Refused"
+                    />
+                    <field name="consent_required" invisible="1"/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>
@@ -34,10 +56,16 @@
                         </button>
                     </div>
                     <group>
-                        <field name="partner_id"/>
-                        <field name="activity_id"/>
-                        <field name="accepted"/>
-                        <field name="last_metadata"/>
+                        <group>
+                            <field name="partner_id"/>
+                            <field name="activity_id"/>
+                            <field name="accepted"/>
+                            <field name="last_metadata"/>
+                        </group>
+                        <group>
+                            <field name="accepted_date"/>
+                            <field name="refusal_date"/>
+                        </group>
                     </group>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
Adds a full manual mode for more flexibility
Adds accepted and refusal dates as info is not easily accessible as in chatter