### PR TITLE
[FIX] privacy_consent: make it work, basically

### DIFF
--- a/privacy_consent/__manifest__.py
+++ b/privacy_consent/__manifest__.py
@@ -20,6 +20,7 @@
         "data/ir_actions_server.xml",
         "data/ir_cron.xml",
         "data/mail.xml",
+        "templates/assets.xml",
         "templates/form.xml",
         "views/privacy_consent.xml",
         "views/privacy_activity.xml",

--- a/privacy_consent/models/mail_mail.py
+++ b/privacy_consent/models/mail_mail.py
@@ -37,7 +37,7 @@ class MailMail(models.Model):
             failure_type=failure_type,
         )
 
-    def send_get_mail_body(self, partner=None):
+    def _send_prepare_body(self):
         """Replace privacy consent magic links.
 
         This replacement is done here instead of directly writing it into
@@ -46,7 +46,7 @@ class MailMail(models.Model):
         which would enable any reader of such thread to impersonate the
         subject and choose in its behalf.
         """
-        result = super(MailMail, self).send_get_mail_body(partner=partner)
+        result = super(MailMail, self)._send_prepare_body()
         # Avoid polluting other model mails
         if self.model != "privacy.consent":
             return result

--- a/privacy_consent/models/privacy_consent.py
+++ b/privacy_consent/models/privacy_consent.py
@@ -150,7 +150,7 @@ class PrivacyConsent(models.Model):
         """Let user manually ask for consent."""
         return {
             "context": {
-                "default_composition_mode": "mass_mail",
+                "default_composition_mode": "comment",
                 "default_model": self._name,
                 "default_res_id": self.id,
                 "default_template_id": self.activity_id.consent_template_id.id,

--- a/privacy_consent/static/src/css/privacy_consent.scss
+++ b/privacy_consent/static/src/css/privacy_consent.scss
@@ -1,0 +1,7 @@
+/* Copyright 2020 Tecnativa - Jairo Llopis
+   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+
+.o_consent_form {
+    // Need !important to override an inline style of max-width: 300px
+    max-width: 100% !important;
+}

--- a/privacy_consent/templates/assets.xml
+++ b/privacy_consent/templates/assets.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 Tecnativa - Jairo Llopis
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+<data>
+
+    <template id="assets_frontend" inherit_id="web.assets_frontend">
+        <xpath expr=".">
+            <link rel="stylesheet" href="/privacy_consent/static/src/css/privacy_consent.scss" />
+        </xpath>
+    </template>
+
+</data>

--- a/privacy_consent/templates/form.xml
+++ b/privacy_consent/templates/form.xml
@@ -9,6 +9,7 @@
              by website layout if website is installed, and otherwise includes
              all possibly needed assets -->
         <t t-call="web.login_layout">
+            <t t-set="login_card_classes" t-value="'o_consent_form'" />
             <div class="container readable">
                 <div class="jumbotron">
                     <h1>Thank you!</h1>


### PR DESCRIPTION
Some little nasty details were overlooked in the v12 migration, due to https://github.com/odoo/odoo/commit/6eda1dcb7a923ed31a68fa0a3aaf3f275c844a7d renaming `send_get_mail_body`, which rendered the module basically useless:

- The wizard used to ask for consent in manual activities did not fill the placeholders, resulting in an awkward UX.

  | Before | After |
  | --- | --- |
  | ![old-manual-body](https://user-images.githubusercontent.com/973709/95359176-23aeb400-08ca-11eb-9247-6ed1241e6b72.png) | ![new-manual-body](https://user-images.githubusercontent.com/973709/95359194-27dad180-08ca-11eb-8566-19ca827b4730.png) |


- The sent mails **did not have the token** to authenticate and actually allow accepting or rejecting. These buttons returned a 500 error.

  | Before | After |
  | --- | --- |
  | ![old-token](https://user-images.githubusercontent.com/973709/95359254-3a550b00-08ca-11eb-8c28-c8ed0f5d5550.png) | ![new-token](https://user-images.githubusercontent.com/973709/95359266-3cb76500-08ca-11eb-996d-dcd991c7772c.png) |



- Once the token is added, the form was ugly.

  | Before | After |
  | --- | --- |
  | ![old-landpage](https://user-images.githubusercontent.com/973709/95359313-49d45400-08ca-11eb-992a-4ae4bf16c3a5.png) | ![new-landpage](https://user-images.githubusercontent.com/973709/95359333-4fca3500-08ca-11eb-8c08-8c5cf14a8c54.png) |



- Sadly, some tests were testing the how and not the what. It is understandable due to the complexity of testing the what, even more without the `Form` utility, new on v12. These are fixed now too.

@Tecnativa TT25868