### PR TITLE
[FIX] privacy_consent: ensure there's always a request user

### DIFF
--- a/privacy_consent/controllers/main.py
+++ b/privacy_consent/controllers/main.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from werkzeug.exceptions import NotFound
 
+from odoo import SUPERUSER_ID
 from odoo.http import Controller, request, route
 
 from odoo.addons.web.controllers.main import ensure_db
@@ -24,8 +25,9 @@ class ConsentController(Controller):
             # If there's a website, we need a user to render the template
             request.uid = request.website.user_id.id
         except AttributeError:
-            # If there's no website, the default is OK
-            pass
+            # If there's no website, be root if there's no UID
+            if not request.uid:
+                request.uid = SUPERUSER_ID
         consent = (
             request.env["privacy.consent"]
             .with_context(subject_answering=True)


### PR DESCRIPTION
As the controller is `auth="none"`, sometimes there's no user. This wasn't a problem on v12 where `sudo()` applied `SUPERUSER_ID` by default (below, line 35). In v13 we need to add it manually to avoid some situations where `self.env.uid == False`.

@Tecnativa