### PR TITLE
[FIX] privacy_consent: dump auth=none for consents

### DIFF
--- a/privacy_consent/controllers/main.py
+++ b/privacy_consent/controllers/main.py
@@ -5,29 +5,18 @@ from datetime import datetime
 
 from werkzeug.exceptions import NotFound
 
-from odoo import SUPERUSER_ID
 from odoo.http import Controller, request, route
-
-from odoo.addons.web.controllers.main import ensure_db
 
 
 class ConsentController(Controller):
     @route(
         "/privacy/consent/<any(accept,reject):choice>/<int:consent_id>/<token>",
         type="http",
-        auth="none",
+        auth="public",
         website=True,
     )
     def consent(self, choice, consent_id, token, *args, **kwargs):
         """Process user's consent acceptance or rejection."""
-        ensure_db()
-        try:
-            # If there's a website, we need a user to render the template
-            request.uid = request.website.user_id.id
-        except AttributeError:
-            # If there's no website, be root if there's no UID
-            if not request.uid:
-                request.uid = SUPERUSER_ID
         consent = (
             request.env["privacy.consent"]
             .with_context(subject_answering=True)


### PR DESCRIPTION
Before this fix, this module would work in a multidatabase instance. However, it would introduce random conflicts when used together with `website_sale` and its dependencies.

According to [docs][1]:

> For servers hosting multiple databases in production, especially if website is used, dbfilter must be set, otherwise a number of features will not work correctly.

If we consider this module to fall into that category, we remove some of its workarounds that were only needed for unsupported scenarios. Less errors with less code.

[1] https://www.odoo.com/documentation/13.0/setup/deploy.html#dbfilter