### PR TITLE
[13.0][FIX] privacy: Change _default_controller_id() to partner_id

### DIFF
--- a/privacy/models/privacy_activity.py
+++ b/privacy/models/privacy_activity.py
@@ -40,4 +40,4 @@ class PrivacyActivity(models.Model):
     @api.model
     def _default_controller_id(self):
         """By default it should be the current user's company."""
-        return self.env.user.company_id
+        return self.env.user.company_id.partner_id


### PR DESCRIPTION
FWP from 12.0: https://github.com/OCA/data-protection/pull/58
Change `_default_controller_id()` to `partner_id`.

Please @Yajo and @pedrobaeza can you review it?

@Tecnativa TT31809