### PR TITLE
[14.0][FIX] Fix description rendering and state rendering

### DIFF
--- a/privacy_consent/data/mail.xml
+++ b/privacy_consent/data/mail.xml
@@ -51,18 +51,18 @@
                                     <i
                                     >${object.activity_id.controller_id.display_name|safe}</i>
                                 </p>
-                                ${object.description or ""}
+                                ${object.activity_id.description or ""}
                                 <p>
                                     % if object.state == "answered":
                                         The last time you answered, you
-                                    % elif object.state == "sent":
+                                    % else:
                                         If you do nothing, we will assume you have
                                     % endif
 
                                     % if object.accepted:
-                                        <b>accepted</b>
+                                    <b>accepted</b>
                                     % else:
-                                        <b>rejected</b>
+                                    <b>rejected</b>
                                     % endif
                                     such data processing.
                                 </p>


### PR DESCRIPTION
The email template is broken. Twice. In first instance it doesn't render activity's description because there's typo in the attribute. Instead of `object.activity_id.description` it only contains `object.description`. Obviously this doesn't cause any error (I found it when I was porting it to 15.0 where the rendering engine changed and produces error).

The other is a logical error when describing state of consent. In case of first one which is in `draft` state no text is being rendered which is confusing then...
![image](https://user-images.githubusercontent.com/19169467/188419847-c7536b7a-d123-4cf2-97dd-2a63084ff5b0.png)
